### PR TITLE
Allow passing positions/atom indexes as numpy ndarrays

### DIFF
--- a/dscribe/descriptors/soap.py
+++ b/dscribe/descriptors/soap.py
@@ -255,22 +255,32 @@ class SOAP(Descriptor):
                     " atomic indices or cartesian coordinates with x, y and z "
                     "components."
                 )
-            for i in positions:
-                if np.issubdtype(type(i), np.integer):
-                    list_positions.append(system.get_positions()[i])
-                elif isinstance(i, list) or isinstance(i, tuple):
-                    if len(i) != 3:
-                        raise ValueError(
-                            "The argument 'positions' should contain a "
-                            "non-empty set of atomic indices or cartesian "
-                            "coordinates with x, y and z components."
-                        )
-                    list_positions.append(i)
+                
+            if isinstance(positions, np.ndarray):
+                if positions.dtype == np.int:
+                    list_positions = system.get_positions()[positions]
                 else:
-                    raise ValueError(
-                        "Create method requires the argument 'positions', a "
-                        "list of atom indices and/or positions"
-                    )
+                    if positions.ndim == 2 and positions.shape[1] == 3:
+                        list_positions = positions
+                    else:
+                        raise ValueError("Invalid `positions` shape %s" % str(positions.shape))
+            else: # Check if it's a correctly formed list
+                for i in positions:
+                    if np.issubdtype(type(i), np.integer):
+                        list_positions.append(system.get_positions()[i])
+                    elif isinstance(i, list) or isinstance(i, tuple):
+                        if len(i) != 3:
+                            raise ValueError(
+                                "The argument 'positions' should contain a "
+                                "non-empty set of atomic indices or cartesian "
+                                "coordinates with x, y and z components."
+                            )
+                        list_positions.append(i)
+                    else:
+                        raise ValueError(
+                            "Create method requires the argument 'positions', a "
+                            "list of atom indices and/or positions"
+                        )
 
             # Determine the SOAPLite function to call based on periodicity and
             # rbf


### PR DESCRIPTION
Simple change to the parameter verification to allow passing `numpy` arrays to `SOAP`'s `positions` argument for ease of use.

The underlying `SOAPLite` implementation turns them into `numpy` arrays later anyway ([`core.py`:112](https://github.com/SINGROUP/SOAPLite/blob/master/soaplite/core.py#L112)), so this should also provide minor efficiency gains.