### PR TITLE
Fix some C++ compiler warnings

### DIFF
--- a/dscribe/ext/celllist.cpp
+++ b/dscribe/ext/celllist.cpp
@@ -152,7 +152,7 @@ CellListResult CellList::getNeighboursForIndex(const int idx) const
     CellListResult result = this->getNeighboursForPosition(x, y, z);
 
     // Remove self from neighbours
-    for (int i=0; i < result.indices.size(); ++i) {
+    for (size_t i=0; i < result.indices.size(); ++i) {
         if (result.indices[i] == idx) {
             result.indices.erase(result.indices.begin() + i);
             result.distances.erase(result.distances.begin() + i);

--- a/dscribe/ext/descriptor.cpp
+++ b/dscribe/ext/descriptor.cpp
@@ -69,7 +69,6 @@ void Descriptor::derivatives_numerical(
     int n_features = this->get_number_of_features();
     auto derivatives_mu = derivatives.mutable_unchecked<4>();
     auto indices_u = indices.unchecked<1>();
-    auto center_indices_u = center_indices.unchecked<1>();
     auto pbc_u = pbc.unchecked<1>();
     py::array_t<int> center_true_indices;
     py::array_t<double> centers_extended;
@@ -83,7 +82,6 @@ void Descriptor::derivatives_numerical(
         atomic_numbers = system_extension.atomic_numbers;
     }
     auto positions_mu = positions.mutable_unchecked<2>();
-    auto atomic_numbers_u = atomic_numbers.unchecked<1>();
 
     // Pre-calculate cell list for atoms
     CellList cell_list_atoms(positions, this->cutoff);

--- a/dscribe/ext/descriptor.cpp
+++ b/dscribe/ext/descriptor.cpp
@@ -139,7 +139,7 @@ void Descriptor::derivatives_numerical(
         if (is_periodic) {
             auto center_true_indices_u = center_true_indices.unchecked<1>();
             set<int> centers_set;
-            for (int i=0; i < centers_local_idx.size(); ++i) {
+            for (size_t i=0; i < centers_local_idx.size(); ++i) {
                 int ext_index = centers_local_idx[i];
                 int true_index = center_true_indices_u(ext_index);
                 centers_set.insert(true_index);
@@ -195,7 +195,7 @@ void Descriptor::derivatives_numerical(
         // to reset the positions after each displacement.
         py::array_t<double> pos({n_copies, 3});
         auto pos_mu = pos.mutable_unchecked<2>();
-        for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+        for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
             int j_copy = i_atom_indices[i_copy];
             for (int i = 0; i < 3; ++i) {
                 pos_mu(i_copy, i) = positions_mu(j_copy, i);
@@ -208,7 +208,7 @@ void Descriptor::derivatives_numerical(
         py::array_t<double> centers_moved({(int)centers_to_move.size(), 3});
         auto centers_moved_mu = centers_moved.mutable_unchecked<2>();
         if (attach) {
-            for (int i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
+            for (size_t i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
                 int j_copy = centers_to_move[i_copy];
                 for (int i = 0; i < 3; ++i) {
                     centers_moved_mu(i_copy, i) = centers_local_pos_mu(j_copy, i);
@@ -221,7 +221,7 @@ void Descriptor::derivatives_numerical(
 
                 // Introduce the displacement(s). Displacement are done for all
                 // periodic copies as well.
-                for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+                for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
                     int j_copy = i_atom_indices[i_copy];
                     positions_mu(j_copy, i_comp) = pos_mu(i_copy, i_comp) + h*displacement[i_stencil];
                 }
@@ -229,7 +229,7 @@ void Descriptor::derivatives_numerical(
                 // If attach = true, we also move the center(s) that are
                 // attached to this atom.
                 if (attach) {
-                    for (int i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
+                    for (size_t i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
                         int j_copy = centers_to_move[i_copy];
                         centers_local_pos_mu(j_copy, i_comp) = centers_moved_mu(i_copy, i_comp) + h*displacement[i_stencil];
                     }
@@ -265,7 +265,7 @@ void Descriptor::derivatives_numerical(
             }
 
             // Return position(s) back to original value for next component.
-            for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+            for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
                 int j_copy = i_atom_indices[i_copy];
                 positions_mu(j_copy, i_comp) = pos_mu(i_copy, i_comp);
             }
@@ -273,7 +273,7 @@ void Descriptor::derivatives_numerical(
             // If attach = true, return center(s) back to original value for
             // next component.
             if (attach) {
-                for (int i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
+                for (size_t i_copy = 0; i_copy < centers_to_move.size(); ++i_copy) {
                     int j_copy = centers_to_move[i_copy];
                     centers_local_pos_mu(j_copy, i_comp) = centers_moved_mu(i_copy, i_comp);
                 }

--- a/dscribe/ext/descriptorglobal.cpp
+++ b/dscribe/ext/descriptorglobal.cpp
@@ -113,7 +113,7 @@ void DescriptorGlobal::derivatives_numerical(
         // to reset the positions after each displacement.
         py::array_t<double> pos({n_copies, 3});
         auto pos_mu = pos.mutable_unchecked<2>();
-        for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+        for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
             int j_copy = i_atom_indices[i_copy];
             for (int i = 0; i < 3; ++i) {
                 pos_mu(i_copy, i) = positions_mu(j_copy, i);
@@ -125,7 +125,7 @@ void DescriptorGlobal::derivatives_numerical(
 
                 // Introduce the displacement(s). Displacement are done for all
                 // periodic copies as well.
-                for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+                for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
                     int j_copy = i_atom_indices[i_copy];
                     positions_mu(j_copy, i_comp) = pos_mu(i_copy, i_comp) + h*displacement[i_stencil];
                 }
@@ -154,7 +154,7 @@ void DescriptorGlobal::derivatives_numerical(
             }
 
             // Return position(s) back to original value for next component.
-            for (int i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
+            for (size_t i_copy = 0; i_copy < i_atom_indices.size(); ++i_copy) {
                 int j_copy = i_atom_indices[i_copy];
                 positions_mu(j_copy, i_comp) = pos_mu(i_copy, i_comp);
             }

--- a/dscribe/ext/geometry.cpp
+++ b/dscribe/ext/geometry.cpp
@@ -28,7 +28,7 @@ inline double dot(const vector<double>& a, const vector<double>& b) {
 
 inline double norm(const vector<double>& a) {
     double accum = 0.0;
-    for (int i = 0; i < a.size(); ++i) {
+    for (size_t i = 0; i < a.size(); ++i) {
         accum += a[i] * a[i];
     }
     return sqrt(accum);

--- a/dscribe/ext/soapGTO.cpp
+++ b/dscribe/ext/soapGTO.cpp
@@ -2294,7 +2294,7 @@ void getPD(
     vector<int> indices = result.indices;
 
     // Loop through all neighbouring centers
-    for (int j_idx = 0; j_idx < indices.size(); ++j_idx) {
+    for (size_t j_idx = 0; j_idx < indices.size(); ++j_idx) {
         int i_center = indices[j_idx];
         int shiftAll = 0;
         for(int j = 0; j < Ts; j++) {

--- a/dscribe/ext/soapGTO.cpp
+++ b/dscribe/ext/soapGTO.cpp
@@ -2007,7 +2007,7 @@ void getCD(
     const vector<int> &indices,
     bool return_derivatives){
   if(Asize == 0){return;}
-  double sumMe = 0; int NsNs = Ns*Ns;  int NsJ = ((lMax+1)*(lMax+1))*Ns*typeJ; int LNsNs;
+  double sumMe = 0; int NsNs = Ns*Ns; int LNsNs;
   int LNs;
   double preExp;
   double preVal;
@@ -2215,8 +2215,6 @@ void getPD(
   int lMax,
   bool crossover
 ) {
-
-    int NsTs100 = Ns*Ts*((lMax+1)*(lMax+1));
 
     // The power spectrum is multiplied by an l-dependent prefactor that comes
     // from the normalization of the Wigner D matrices. This prefactor is


### PR DESCRIPTION
Addresses a part of Issue #74

Warnings that are addressed by this PR:
- [x] -Wsign-compare
- [x] -Wunused-variable
- [x] -Wunused-but-set-variable  
- [ ] -Wmaybe-uninitialized (probably the most important)
- [ ] -Wunused-parameter (from -Wextra)
- [ ] -Wstrict-prototypes (enabled by setup.py but not valid for C++)

I may be able to look at other warnings too if I get time. Thanks.