### PR TITLE
Added missing basis premultiplier to B^{-1} matrix

### DIFF
--- a/docs/src/tutorials/descriptors/sine_matrix.rst
+++ b/docs/src/tutorials/descriptors/sine_matrix.rst
@@ -9,7 +9,7 @@ system with a very low computational cost. The matrix elements are defined by
     M_{ij}^\mathrm{sine}=\left\{
         \begin{matrix}
         0.5 Z_i^{2.4} & \text{for } i = j \\
-            \frac{Z_i Z_j}{\lvert \mathbf{B} \cdot \sum_{k=\{x,y,z\}} \hat{\mathbf{e}}_k \sin^2 \left( \pi \mathbf{B}^{-1} \cdot \left( \mathbf{R}_{i} - \mathbf{R}_{j} \right) \right)\rvert} & \text{for } i \neq j
+            \frac{Z_i Z_j}{\lvert \mathbf{B} \cdot \sum_{k=\{x,y,z\}} \hat{\mathbf{e}}_k \sin^2 \left( \pi \hat{\mathbf{e}}_k \mathbf{B}^{-1} \cdot \left( \mathbf{R}_{i} - \mathbf{R}_{j} \right) \right)\rvert} & \text{for } i \neq j
         \end{matrix}
         \right.
     \end{equation}


### PR DESCRIPTION
According to the cited work

> Felix Faber, Alexander Lindmaa, O. Anatole von Lilienfeld, and Rickard Armiento. Crystal structure representations for machine learning models of formation energies. International Journal of Quantum Chemistry, 115(16):1094–1101, 8 2015. doi:10.1002/qua.24917.

(page 1098, eqn. 24)

the matrix should be multiplied by the basis vector to form a row vector, so you get a real number in the sine argument.