### PR TITLE
MBTR smooth_cutoff fix and derivatives

### DIFF
--- a/dscribe/descriptors/mbtr.py
+++ b/dscribe/descriptors/mbtr.py
@@ -881,9 +881,10 @@ class MBTR(DescriptorGlobal):
                     m = int(j + i * n_elem - i * (i + 1) / 2)
                     start = m * n
                     end = (m + 1) * n
-                    y_normed = (k2[start:end] * volume) / (count_product * 4 * np.pi)
+                    norm_factor = volume / (count_product * 4 * np.pi)
 
-                    k2[start:end] = y_normed
+                    k2[start:end] *= norm_factor
+                    k2_d[:, :, start:end] *= norm_factor
 
         # Convert to the final output precision.
         if self.dtype == "float32":
@@ -932,9 +933,9 @@ class MBTR(DescriptorGlobal):
                 parameters = {b"sharpness": sharpness, b"cutoff": weighting["r_cut"]}
                 # Evaluating smooth-cutoff weighting values requires distances
                 # between two neighbours of an atom, and the maximum distance
-                # between them is twice the cutoff radius. To include the 
-                # neighbour-to-neighbour distances in the distance matrix, the 
-                # neighbour list is generated with the double radius.
+                # between them is twice the cutoff radius. To include the
+                # neighbour-to-neighbour distances in the distance matrix, the
+                # neighbour list is generated with double radius.
                 r_cut = 2 * weighting["r_cut"]
         else:
             weighting_function = "unity"
@@ -1038,8 +1039,10 @@ class MBTR(DescriptorGlobal):
                         start = m * n
                         end = (m + 1) * n
                         count_product = counts[i_z] * counts[j_z] * counts[k_z]
-                        y_normed = (k3[start:end] * volume) / count_product
-                        k3[start:end] = y_normed
+                        norm_factor = volume / count_product
+
+                        k3[start:end] *= norm_factor
+                        k3_d[:, :, start:end] *= norm_factor
 
         # Convert to the final output precision.
         if self.dtype == "float32":
@@ -1063,7 +1066,7 @@ class MBTR(DescriptorGlobal):
 
         # Check if analytical derivatives can be used
         try:
-            supported_normalization = ["none", "n_atoms"]
+            supported_normalization = ["none", "n_atoms", "valle_oganov"]
             if self.normalization not in supported_normalization:
                 raise ValueError(
                     "Analytical derivatives not implemented for normalization option '{}'. Please choose from: {}".format(

--- a/dscribe/descriptors/mbtr.py
+++ b/dscribe/descriptors/mbtr.py
@@ -1072,12 +1072,6 @@ class MBTR(DescriptorGlobal):
                 )
             # Derivatives are not currently implemented for all k3 options
             if self.k3 is not None:
-                if self.k3.get("weighting") is not None:
-                    if self.k3["weighting"]["function"] == "smooth_cutoff":
-                        raise ValueError(
-                            "Analytical derivatives not implemented for k3 weighting function 'smooth_cutoff'."
-                        )
-
                 # "angle" function is not differentiable
                 if self.k3["geometry"]["function"] == "angle":
                     raise ValueError(

--- a/dscribe/descriptors/mbtr.py
+++ b/dscribe/descriptors/mbtr.py
@@ -929,8 +929,13 @@ class MBTR(DescriptorGlobal):
                     sharpness = weighting["sharpness"]
                 except Exception:
                     sharpness = 2
-                r_cut = weighting["r_cut"]
-                parameters = {b"sharpness": sharpness, b"cutoff": r_cut}
+                parameters = {b"sharpness": sharpness, b"cutoff": weighting["r_cut"]}
+                # Evaluating smooth-cutoff weighting values requires distances
+                # between two neighbours of an atom, and the maximum distance
+                # between them is twice the cutoff radius. To include the 
+                # neighbour-to-neighbour distances in the distance matrix, the 
+                # neighbour list is generated with the double radius.
+                r_cut = 2 * weighting["r_cut"]
         else:
             weighting_function = "unity"
 

--- a/dscribe/ext/mbtr.cpp
+++ b/dscribe/ext/mbtr.cpp
@@ -327,6 +327,9 @@ void MBTR::getK3(py::array_t<double> &descriptor, py::array_t<double> &derivativ
                 } else if (weightFunc == "smooth_cutoff") {
                     double sharpness = parameters.at("sharpness");
                     double cutoff = parameters.at("cutoff");
+                    if (d_ji > cutoff || d_jk > cutoff){
+                        continue;
+                    }
                     weight = k3WeightSmooth(i, j, k, distances, sharpness, cutoff);
                     if (return_derivatives) {
                         throw invalid_argument("Derivatives not implemented for weighting function 'smooth_cutoff'.");

--- a/dscribe/ext/mbtr.cpp
+++ b/dscribe/ext/mbtr.cpp
@@ -325,14 +325,28 @@ void MBTR::getK3(py::array_t<double> &descriptor, py::array_t<double> &derivativ
                         weight_d[2] = vector<double>(3,0.0);
                     }
                 } else if (weightFunc == "smooth_cutoff") {
-                    double sharpness = parameters.at("sharpness");
+                    double y = parameters.at("sharpness");
                     double cutoff = parameters.at("cutoff");
                     if (d_ji > cutoff || d_jk > cutoff){
                         continue;
                     }
-                    weight = k3WeightSmooth(i, j, k, distances, sharpness, cutoff);
-                    if (return_derivatives) {
-                        throw invalid_argument("Derivatives not implemented for weighting function 'smooth_cutoff'.");
+                    //weight = k3WeightSmooth(i, j, k, distances, y, cutoff);
+                    double frac_ij = d_ji/cutoff;
+                    double frac_jk = d_jk/cutoff;
+                    double pow1_ij = pow(frac_ij, y+1);
+                    double pow2_ij = pow(frac_ij, y);
+                    double pow1_jk = pow(frac_jk, y+1);
+                    double pow2_jk = pow(frac_jk, y);
+                    double f_ij = 1 + y*pow1_ij - (y+1)*pow2_ij;
+                    double f_jk = 1 + y*pow1_jk - (y+1)*pow2_jk;
+                    weight = f_ij*f_jk;
+
+                    double c1 = y*(y+1)/(d_ji*d_ji)*(pow1_ij-pow2_ij)/f_ij;
+                    double c2 = y*(y+1)/(d_jk*d_jk)*(pow1_jk-pow2_jk)/f_jk;
+                    for(int dim=0; dim<3; ++dim){
+                        weight_d[0].push_back(-c1*r_ji[dim]);
+                        weight_d[1].push_back( c2*r_jk[dim] + c1*r_ji[dim]);
+                        weight_d[2].push_back(-c2*r_jk[dim]);
                     }
                 } else {
                     throw invalid_argument("Invalid weighting function.");

--- a/tests/test_mbtr.py
+++ b/tests/test_mbtr.py
@@ -95,6 +95,8 @@ def k3_dict(weighting_function):
 
     if weighting_function == "exp":
         d["weighting"] = {"function": "exp", "scale": 1.0, "threshold": 1e-3}
+    elif weighting_function == "smooth_cutoff":
+        d["weighting"] = {"function": "smooth_cutoff", "sharpness": 2.0, "r_cut": 6.0}
 
     return d
 
@@ -220,7 +222,21 @@ def test_symmetries():
         (
             "analytical",
             True,
+            "none",
+            k2_dict("distance", "exp"),
+            k3_dict("smooth_cutoff"),
+        ),
+        (
+            "analytical",
+            True,
             "n_atoms",
+            k2_dict("inverse_distance", "exp"),
+            k3_dict("exp"),
+        ),
+        (
+            "analytical",
+            True,
+            "valle_oganov",
             k2_dict("inverse_distance", "exp"),
             k3_dict("exp"),
         ),

--- a/tests/test_valle_oganov.py
+++ b/tests/test_valle_oganov.py
@@ -16,8 +16,8 @@ from dscribe.descriptors import ValleOganov, MBTR
 
 # =============================================================================
 # Utilities
-default_k2 = {"sigma": 10 ** (-0.625), "n": 10, "r_cut": 2}
-default_k3 = {"sigma": 10 ** (-0.625), "n": 10, "r_cut": 2}
+default_k2 = {"sigma": 10 ** (-0.625), "n": 10, "r_cut": 2.1}
+default_k3 = {"sigma": 10 ** (-0.625), "n": 10, "r_cut": 2.1}
 
 
 def valle_oganov(**kwargs):
@@ -75,6 +75,10 @@ def test_symmetries():
 
 def test_derivatives_numerical():
     assert_derivatives(valle_oganov(), "numerical", False)
+
+
+def test_derivatives_analytical():
+    assert_derivatives(valle_oganov(k3=None), "analytical", False)
 
 
 @pytest.mark.parametrize("method", ("numerical",))


### PR DESCRIPTION
Fixes a bug in the MBTR k3 weighting function "smooth_cutoff", where the pair-wise distance matrix was not computed far enough to include all the required neighbour-to-neighbour distances.

Also adds analytical derivatives for "smooth_cutoff" and normalization option "valle_oganov". As a result, analytical derivatives are now supported for the k2-term of ValleOganov-descriptor.