### PR TITLE
change-np-int-to-int

### DIFF
--- a/dscribe/descriptors/descriptorglobal.py
+++ b/dscribe/descriptors/descriptorglobal.py
@@ -87,11 +87,11 @@ class DescriptorGlobal(Descriptor):
         n_samples = len(system)
         if include is None:
             include = [None] * n_samples
-        elif is1d(include, np.integer):
+        elif is1d(include, int):
             include = [include] * n_samples
         if exclude is None:
             exclude = [None] * n_samples
-        elif is1d(exclude, np.integer):
+        elif is1d(exclude, int):
             exclude = [exclude] * n_samples
         n_inc = len(include)
         if n_inc != n_samples:

--- a/dscribe/descriptors/descriptorlocal.py
+++ b/dscribe/descriptors/descriptorlocal.py
@@ -139,11 +139,11 @@ class DescriptorLocal(Descriptor):
             centers = [None] * n_samples
         if include is None:
             include = [None] * n_samples
-        elif is1d(include, np.integer):
+        elif is1d(include, int):
             include = [include] * n_samples
         if exclude is None:
             exclude = [None] * n_samples
-        elif is1d(exclude, np.integer):
+        elif is1d(exclude, int):
             exclude = [exclude] * n_samples
         n_pos = len(centers)
         if n_pos != n_samples:
@@ -351,7 +351,7 @@ class DescriptorLocal(Descriptor):
         deltas = [-1.0, 1.0]
         if centers is None:
             centers = range(len(system))
-        if not attach and np.issubdtype(type(centers[0]), np.integer):
+        if not attach and np.issubdtype(type(centers[0]), int):
             centers = system.get_positions()[centers]
 
         for index, i_atom in enumerate(indices):

--- a/dscribe/descriptors/lmbtr.py
+++ b/dscribe/descriptors/lmbtr.py
@@ -427,7 +427,7 @@ class LMBTR(DescriptorLocal):
                     "components."
                 )
             for i in centers:
-                if np.issubdtype(type(i), np.integer):
+                if np.issubdtype(type(i), int):
                     i_len = len(system)
                     if i >= i_len or i < 0:
                         raise ValueError(

--- a/dscribe/descriptors/soap.py
+++ b/dscribe/descriptors/soap.py
@@ -304,9 +304,9 @@ class SOAP(DescriptorLocal):
             if not isinstance(centers, (list, tuple, np.ndarray)) or len(centers) == 0:
                 raise error
             list_positions = []
-            indices = np.full(len(centers), -1, dtype=np.int64)
+            indices = np.full(len(centers), -1, dtype=int)
             for idx, i in enumerate(centers):
-                if np.issubdtype(type(i), np.integer):
+                if np.issubdtype(type(i), int):
                     list_positions.append(system.get_positions()[i])
                     indices[idx] = i
                 elif isinstance(i, (list, tuple, np.ndarray)):

--- a/dscribe/utils/dimensionality.py
+++ b/dscribe/utils/dimensionality.py
@@ -16,7 +16,7 @@ limitations under the License.
 import numpy as np
 
 
-def is1d(array, dtype=np.integer):
+def is1d(array, dtype=int):
     try:
         for i in array:
             if not np.issubdtype(type(i), dtype):
@@ -26,7 +26,7 @@ def is1d(array, dtype=np.integer):
     return True
 
 
-def is2d(array, dtype=np.integer):
+def is2d(array, dtype=int):
     try:
         for i in array:
             for j in i:

--- a/dscribe/utils/species.py
+++ b/dscribe/utils/species.py
@@ -59,13 +59,13 @@ def get_atomic_numbers(species):
         raise ValueError("Please provide the species as an iterable, e.g. a list.")
 
     # Determine if the given species are atomic numbers or chemical symbols
-    if all(isinstance(x, (int, np.integer)) for x in species):
+    if all(isinstance(x, int) for x in species):
         if any([x < 0 for x in species]):
             raise ValueError(
                 "The given list of species contains negative integers. Please use only non-negative integers"
             )
         atomic_numbers = species
-    elif all(isinstance(x, (str, np.str_)) for x in species):
+    elif all(isinstance(x, str) for x in species):
         atomic_numbers = symbols_to_numbers(species)
     else:
         raise ValueError(


### PR DESCRIPTION
The np.int and np.integer have been deprecated. In my commit, I have changed these to "int" type.